### PR TITLE
enable tracker for line crossing

### DIFF
--- a/config/dstest_occupancy_analytics.txt
+++ b/config/dstest_occupancy_analytics.txt
@@ -193,6 +193,7 @@ config-file=pgie_peoplenet_tao_config.txt
 #infer-raw-output-dir=../../../../../samples/primary_detector_raw_output/
 
 [tracker]
+enable=1
 tracker-width=640
 tracker-height=384
 gpu-id=0


### PR DESCRIPTION
track is needed line crossing checking. please refer to topic [.](https://forums.developer.nvidia.com/t/does-deepstream-occupancy-analytics-work-with-deepstream-6-3/269180) 